### PR TITLE
Strategia compatibility

### DIFF
--- a/GameData/KGEx/Komplexity/Patches/Administration.cfg
+++ b/GameData/KGEx/Komplexity/Patches/Administration.cfg
@@ -1,10 +1,10 @@
-// Administration.cfg v1.0.6.0
-// Komplexity
-// a addon that used CustomBarnKit to extend the Kerbin Space Center's facilities from four levels (start + three) to ten levels (start + nine)
+// Administration.cfg v1.0.7.0
+// Komplexity (KPLX)
+// an addon that used CustomBarnKit to extend the Kerbin Space Center's facilities from four levels (start + three) to ten levels (start + nine)
 // created: 05 Nov 2019 
-// updated: 17 Jun 2021
+// updated: 17 Jan 2021
 
-@CUSTOMBARNKIT:NEEDS[CustomBarnKit,!Strategia]:AFTER[CustomBarnKit]
+@CUSTOMBARNKIT:NEEDS[CustomBarnKit,!Strategia]:FOR[Komplexity]
 {
 	@ADMINISTRATION
 	{
@@ -16,5 +16,5 @@
 	}
 }
 
-// GPL 2.0
+// GPL 2.0 BY
 // zer0Kerbal

--- a/GameData/KGEx/Komplexity/Patches/MissionControl.cfg
+++ b/GameData/KGEx/Komplexity/Patches/MissionControl.cfg
@@ -1,10 +1,10 @@
-// MissionControl.cfg v1.0.5.0
-// Komplexity
-// a addon that used CustomBarnKit to extend the Kerbin Space Center's facilities from four levels (start + three) to ten levels (start + nine)
+// MissionControl.cfg v1.0.50
+// Komplexity (KPLX)
+// an addon that used CustomBarnKit to extend the Kerbin Space Center's facilities from four levels (start + three) to ten levels (start + nine)
 // created: 05 Nov 2019 
-// updated: 15 Jun 2021
+// updated: 17 Jan 2021
 
-@CUSTOMBARNKIT:NEEDS[CustomBarnKit]:AFTER[CustomBarnKit]
+@CUSTOMBARNKIT:NEEDS[CustomBarnKit]:FOR[Komplexity]
 {
 	@MISSION
 	{
@@ -17,5 +17,5 @@
 	}
 }
 
-// GPL 2.0
+// GPL 2.0 BY
 // zer0Kerbal


### PR DESCRIPTION
# Strategia compatibility
- makes MissionControl.cfg on by default (doesn't affect Strategia)
- adjusts the :NEEDS for Administration.cfg to !Strategia(only work if Strategia isn't present)
- changes the :AFTER[] to :FOR[Komplexity]
- closes #25 